### PR TITLE
refactor: 디자인 시스템 타이포그래피 및 버튼 인터랙션 보정

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -12,8 +12,8 @@
   --color-secondary-subtext: #9e9892;
 
   /* Interaction States */
-  --color-state-hover: #ff9f6b;
-  --color-state-active: #e5662a;
+  --color-state-hover: #e5662a;
+  --color-state-active: #cc5a25;
   --color-shadow: #ff7e3633;
 
   /* Gray Scale */
@@ -65,21 +65,25 @@
 
   /* Typography - Font Weight */
   --font-weight-regular: 400;
+  --font-weight-medium: 500;
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
+  --font-weight-extrabold: 800;
 
   /*layout */
   --container-layout: 375px;
 }
 
 @utility typo-display1 {
+  font-family: var(--font-suit);
   font-size: var(--text-h1);
   line-height: var(--leading-h1);
   letter-spacing: var(--tracking-h1);
-  font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-extrabold);
 }
 
 @utility typo-h1-title {
+  font-family: var(--font-suit);
   font-size: var(--text-h2);
   line-height: var(--leading-h2);
   letter-spacing: var(--tracking-h2);
@@ -87,17 +91,18 @@
 }
 
 @utility typo-h2-sub {
+  font-family: var(--font-suit);
   font-size: var(--text-h3);
   line-height: var(--leading-h3);
   letter-spacing: var(--tracking-h3);
-  font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-semibold);
 }
 
 @utility typo-body1 {
   font-size: var(--text-body1);
   line-height: var(--leading-body1);
   letter-spacing: var(--tracking-body1);
-  font-weight: var(--font-weight-regular);
+  font-weight: var(--font-weight-medium);
 }
 
 @utility typo-body2 {
@@ -126,10 +131,6 @@
   line-height: var(--leading-caption);
   letter-spacing: var(--tracking-body2);
   font-weight: var(--font-weight-semibold);
-}
-
-@utility font-suit {
-  font-family: var(--font-suit);
 }
 
 html {

--- a/components/ui/button/floatingButton/FloatingButton.tsx
+++ b/components/ui/button/floatingButton/FloatingButton.tsx
@@ -19,15 +19,14 @@ const floatingButtonVariants = cva(
     "rounded-full",
     "flex w-fit gap-2",
     "typo-button text-center justify-center items-center",
-    "active:bg-state-active",
     "[&_svg]:w-6 [&_svg]:h-6",
     "shadow-[0px_4px_12px_0px_var(--color-shadow)]",
   ],
   {
     variants: {
       variant: {
-        primary: ["bg-primary-point", "text-white", "py-3", "px-6"],
-        primaryIcon: ["bg-primary-point", "text-white", "p-3"],
+        primary: ["bg-primary-point", "text-white", "py-3", "px-6", "hover:bg-state-hover", "active:bg-state-active"],
+        primaryIcon: ["bg-primary-point", "text-white", "p-3", "hover:bg-state-hover", "active:bg-state-active"],
         /** 추후 다른 디자인 시스템이 추가된다면 이곳을 변경 */
       },
       disabled: {

--- a/components/ui/tabmenu/Tabmenu.tsx
+++ b/components/ui/tabmenu/Tabmenu.tsx
@@ -37,7 +37,7 @@ const Tabmenu = ({ selectedTab }: TabmenuProps) => {
           )}
         >
           {info.icon}
-          <span className="typo-body2 font-suit"> {info.label}</span>
+          <span className="typo-body2">{info.label}</span>
         </Link>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- 디자인 스펙에 맞게 타이포그래피 유틸리티 클래스의 font-weight, font-family 보정 (Display1: extrabold, H2: semibold, Body1: medium)
- Display/H1/H2 유틸리티에 SUIT 폰트 패밀리 직접 지정하여 불필요한 `font-suit` 유틸리티 클래스 제거
- hover/active 인터랙션 컬러를 base보다 어둡게 변경하여 disabled 상태와 시각적 구분 확보
- FloatingButton primary 변형에 hover/active 상태 적용

<img width="707" height="236" alt="image" src="https://github.com/user-attachments/assets/c4e7c04e-e37b-44c0-8cf4-580c310de153" />

## ISSUE
Closes #21 

## 논의 사항
- 피그마에 정의된 Button의 active, hover 컬러가 시각적으로 눈에 잘 보이지 않는다는 문제 존재
- 임의로 색상을 변경함, 회의 때 의논 필요