### PR TITLE
feature: Swiper 컴포넌트 구현

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -75,6 +75,7 @@
 
   /*layout */
   --container-layout: 375px;
+  --layout-padding-x: 16px;
 }
 
 @utility typo-display1 {

--- a/components/ui/swiperAction/SwiperAction.stories.tsx
+++ b/components/ui/swiperAction/SwiperAction.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import SwiperAction from "./SwiperAction";
+
+const meta: Meta<typeof SwiperAction> = {
+  title: "UI/SwiperAction/SwiperAction",
+  component: SwiperAction,
+};
+
+export default meta;
+type Story = StoryObj<typeof SwiperAction>;
+
+const cards = ["🍜 라멘", "🍕 피자", "🌮 타코", "🍣 스시", "🥗 샐러드"];
+
+const SlideCard = ({ label }: { label: string }) => (
+  <div className="flex items-center justify-center h-40 rounded-2xl bg-bg-white text-gray-900 typo-h1-title shadow-sm w-80">{label}</div>
+);
+
+const defaultElements = cards.map((label) => <SlideCard key={label} label={label} />);
+const singleElement = [<SlideCard key="single" label="🍜 라멘" />];
+
+export const Default: Story = {
+  render: (args) => <SwiperAction {...args} swiperElement={defaultElements} />,
+};
+
+export const WithSidePeek: Story = {
+  render: (args) => <SwiperAction {...args} swiperElement={defaultElements} />,
+  args: {
+    sidePeekRatio: 0.06,
+  },
+};
+
+export const SingleSlide: Story = {
+  render: (args) => <SwiperAction {...args} swiperElement={singleElement} />,
+};

--- a/components/ui/swiperAction/SwiperAction.tsx
+++ b/components/ui/swiperAction/SwiperAction.tsx
@@ -1,0 +1,68 @@
+import { motion } from "motion/react";
+import { VisuallyHidden } from "../../../styles/VisuallyHidden";
+import useSwiperAction from "./useSwiperAction";
+
+interface SwiperActionProps {
+  /** 슬라이드로 전달되는 요소 리스트 */
+  swiperElement: React.ReactNode[];
+  /** 슬라이드 양옆에 보이게 할 여유 공간 비율(요소 너비 대비) */
+  sidePeekRatio?: number;
+}
+
+const SwiperAction = ({ swiperElement, sidePeekRatio }: SwiperActionProps) => {
+  const {
+    containerRef,
+    trackRef,
+    currentIndex,
+    styleGap,
+    slideWidth,
+    x,
+    shouldPreventClick,
+    moveToLeft,
+    moveToRight,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    handlePointerLeave,
+  } = useSwiperAction({
+    length: swiperElement.length,
+    sidePeekRatio,
+  });
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex w-full overflow-hidden touch-none bg-bg-oatmeal"
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerMove={handlePointerMove}
+      onPointerLeave={handlePointerLeave}
+    >
+      {currentIndex !== 0 && <VisuallyHidden tabIndex={0} aria-label="이전으로 이동" aria-hidden={currentIndex === 0} onClick={moveToLeft} />}
+      <motion.div ref={trackRef} className="flex items-center" style={{ x, gap: styleGap }}>
+        {swiperElement.map((element, index) => (
+          <div
+            // biome-ignore lint/suspicious/noArrayIndexKey: 현재로썬 index만 사용 가능함
+            key={index}
+            className="flex justify-center overflow-hidden shrink-0 select-none w-[calc(var(--container-layout)-var(--layout-padding-x)*2)]"
+            style={slideWidth !== null ? { width: slideWidth } : undefined}
+            onClickCapture={(e) => {
+              if (shouldPreventClick.current) {
+                e.stopPropagation();
+                return;
+              }
+            }}
+            aria-hidden={currentIndex !== index}
+          >
+            {element}
+          </div>
+        ))}
+      </motion.div>
+      {currentIndex !== swiperElement.length - 1 && (
+        <VisuallyHidden tabIndex={0} aria-label="다음으로 이동" aria-hidden={currentIndex === swiperElement.length - 1} onClick={moveToRight} />
+      )}
+    </div>
+  );
+};
+
+export default SwiperAction;

--- a/components/ui/swiperAction/SwiperAction.tsx
+++ b/components/ui/swiperAction/SwiperAction.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { motion } from "motion/react";
 import { VisuallyHidden } from "../../../styles/VisuallyHidden";
 import useSwiperAction from "./useSwiperAction";

--- a/components/ui/swiperAction/useSwiperAction.ts
+++ b/components/ui/swiperAction/useSwiperAction.ts
@@ -1,0 +1,177 @@
+import { animate, type Transition, useMotionValue } from "motion/react";
+import { useEffect, useRef, useState } from "react";
+
+interface UseSwiperActionProps {
+  length: number;
+  sidePeekRatio?: number;
+}
+
+const useSwiperAction = ({ length, sidePeekRatio }: UseSwiperActionProps) => {
+  const springPreset: Transition = {
+    type: "spring",
+    stiffness: 450,
+    damping: 32,
+    mass: 0.3,
+  };
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+
+  const elementWidthRef = useRef(0);
+  const containerWidthRef = useRef(0);
+
+  const startX = useRef(0);
+  const startY = useRef(0);
+  const threshold = useRef(0);
+  const isDragging = useRef(false);
+  const shouldPreventClick = useRef(false);
+
+  const x = useMotionValue(0);
+  const MIN_THRESHOLD = 5;
+  const STANDARD = 5;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: 첫 마운트시에만 계산
+  useEffect(() => {
+    const updateLayout = () => {
+      const root = getComputedStyle(document.documentElement);
+      const padding = Number(root.getPropertyValue("--layout-padding-x").replace("px", ""));
+
+      containerWidthRef.current = containerRef.current?.clientWidth ?? 0;
+
+      const contentWidth = containerWidthRef.current - 2 * padding;
+      const sw = sidePeekRatio ? contentWidth / (1 + 2 * sidePeekRatio) : contentWidth;
+      elementWidthRef.current = sw;
+      setSlideWidth(sw);
+
+      threshold.current = Math.floor((containerWidthRef.current - 2 * padding) / STANDARD);
+      x.set(calculateLocation(0));
+    };
+    updateLayout();
+
+    window.addEventListener("resize", updateLayout);
+    return () => window.removeEventListener("resize", updateLayout);
+  }, []);
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [styleGap, setStyleGap] = useState(0);
+  const [slideWidth, setSlideWidth] = useState<number | null>(null);
+
+  const calculateLocation = (index: number) => {
+    const slice = sidePeekRatio ? elementWidthRef.current * sidePeekRatio : 0;
+    const gap = (containerWidthRef.current - (elementWidthRef.current + slice * 2)) / 2;
+    const start = gap + slice;
+
+    setStyleGap(gap);
+
+    const move = elementWidthRef.current + gap;
+
+    return Math.floor(start - move * index);
+  };
+
+  const updateLocation = (index: number) => {
+    animate(x, calculateLocation(index), springPreset);
+  };
+
+  const snapToIndex = (diffX: number) => {
+    const ableToMoveLeft = diffX >= threshold.current;
+    const ableToMoveRight = diffX <= -threshold.current;
+
+    if (ableToMoveLeft && currentIndex < length - 1) {
+      const nextIndex = currentIndex + 1;
+      setCurrentIndex(nextIndex);
+      animate(x, calculateLocation(nextIndex), springPreset);
+      return;
+    }
+    if (ableToMoveRight && currentIndex > 0) {
+      const nextIndex = currentIndex - 1;
+      setCurrentIndex(nextIndex);
+      animate(x, calculateLocation(nextIndex), springPreset);
+      return;
+    }
+    animate(x, calculateLocation(currentIndex), springPreset);
+  };
+
+  const moveToRight = () => {
+    const next = currentIndex + 1;
+    if (next >= length) return;
+    setCurrentIndex(next);
+    updateLocation(next);
+  };
+
+  const moveToLeft = () => {
+    const prev = currentIndex - 1;
+    if (prev < 0) return;
+    setCurrentIndex(prev);
+    updateLocation(prev);
+  };
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    if (length === 0) return;
+
+    isDragging.current = true;
+    startX.current = e.clientX;
+    startY.current = e.clientY;
+  };
+
+  const handlePointerMove = (e: React.PointerEvent) => {
+    if (!isDragging.current) return;
+    if (length === 0) return;
+    if (!trackRef.current) return;
+
+    const diffX = startX.current - e.clientX;
+    const diffY = startY.current - e.clientY;
+    if (Math.abs(diffY) > Math.abs(diffX)) {
+      isDragging.current = false;
+      return;
+    }
+    if (Math.abs(diffX) > MIN_THRESHOLD) {
+      shouldPreventClick.current = true;
+    }
+    x.set(calculateLocation(currentIndex) - diffX);
+  };
+
+  const handlePointerUp = (e: React.PointerEvent) => {
+    if (length === 0) return;
+
+    isDragging.current = false;
+
+    const diffX = startX.current - e.clientX;
+    const diffY = startY.current - e.clientY;
+
+    // 이동 거리가 MIN_THRESHOLD 이하라면 브라우저의 click 이벤트로 처리
+    const isClickEvent = Math.abs(diffX) < MIN_THRESHOLD;
+    if (isClickEvent) {
+      shouldPreventClick.current = false;
+      return;
+    }
+    if (Math.abs(diffY) > Math.abs(diffX)) {
+      shouldPreventClick.current = false;
+      return;
+    }
+
+    snapToIndex(diffX);
+  };
+
+  const handlePointerLeave = () => {
+    isDragging.current = false;
+    animate(x, calculateLocation(currentIndex), springPreset);
+  };
+
+  return {
+    containerRef,
+    trackRef,
+    currentIndex,
+    styleGap,
+    slideWidth,
+    x,
+    shouldPreventClick,
+    moveToLeft,
+    moveToRight,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+    handlePointerLeave,
+  };
+};
+
+export default useSwiperAction;

--- a/components/ui/swiperAction/useSwiperAction.ts
+++ b/components/ui/swiperAction/useSwiperAction.ts
@@ -39,8 +39,6 @@ const useSwiperAction = ({ length, sidePeekRatio }: UseSwiperActionProps) => {
     const gap = (containerWidthRef.current - (elementWidthRef.current + slice * 2)) / 2;
     const start = gap + slice;
 
-    setStyleGap(gap);
-
     const move = elementWidthRef.current + gap;
 
     return Math.floor(start - move * index);
@@ -147,6 +145,10 @@ const useSwiperAction = ({ length, sidePeekRatio }: UseSwiperActionProps) => {
       const sw = sidePeekRatio ? contentWidth / (1 + 2 * sidePeekRatio) : contentWidth;
       elementWidthRef.current = sw;
       setSlideWidth(sw);
+
+      const slice = sidePeekRatio ? elementWidthRef.current * sidePeekRatio : 0;
+      const gap = (containerWidthRef.current - (elementWidthRef.current + slice * 2)) / 2;
+      setStyleGap(gap);
 
       threshold.current = Math.floor((containerWidthRef.current - 2 * padding) / STANDARD);
       x.set(calculateLocation(0));

--- a/components/ui/swiperAction/useSwiperAction.ts
+++ b/components/ui/swiperAction/useSwiperAction.ts
@@ -30,28 +30,6 @@ const useSwiperAction = ({ length, sidePeekRatio }: UseSwiperActionProps) => {
   const MIN_THRESHOLD = 5;
   const STANDARD = 5;
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: 첫 마운트시에만 계산
-  useEffect(() => {
-    const updateLayout = () => {
-      const root = getComputedStyle(document.documentElement);
-      const padding = Number(root.getPropertyValue("--layout-padding-x").replace("px", ""));
-
-      containerWidthRef.current = containerRef.current?.clientWidth ?? 0;
-
-      const contentWidth = containerWidthRef.current - 2 * padding;
-      const sw = sidePeekRatio ? contentWidth / (1 + 2 * sidePeekRatio) : contentWidth;
-      elementWidthRef.current = sw;
-      setSlideWidth(sw);
-
-      threshold.current = Math.floor((containerWidthRef.current - 2 * padding) / STANDARD);
-      x.set(calculateLocation(0));
-    };
-    updateLayout();
-
-    window.addEventListener("resize", updateLayout);
-    return () => window.removeEventListener("resize", updateLayout);
-  }, []);
-
   const [currentIndex, setCurrentIndex] = useState(0);
   const [styleGap, setStyleGap] = useState(0);
   const [slideWidth, setSlideWidth] = useState<number | null>(null);
@@ -156,6 +134,28 @@ const useSwiperAction = ({ length, sidePeekRatio }: UseSwiperActionProps) => {
     isDragging.current = false;
     animate(x, calculateLocation(currentIndex), springPreset);
   };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: 첫 마운트시에만 계산
+  useEffect(() => {
+    const updateLayout = () => {
+      const root = getComputedStyle(document.documentElement);
+      const padding = Number(root.getPropertyValue("--layout-padding-x").replace("px", ""));
+
+      containerWidthRef.current = containerRef.current?.clientWidth ?? 0;
+
+      const contentWidth = containerWidthRef.current - 2 * padding;
+      const sw = sidePeekRatio ? contentWidth / (1 + 2 * sidePeekRatio) : contentWidth;
+      elementWidthRef.current = sw;
+      setSlideWidth(sw);
+
+      threshold.current = Math.floor((containerWidthRef.current - 2 * padding) / STANDARD);
+      x.set(calculateLocation(0));
+    };
+    updateLayout();
+
+    window.addEventListener("resize", updateLayout);
+    return () => window.removeEventListener("resize", updateLayout);
+  }, []);
 
   return {
     containerRef,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "motion": "^12.34.2",
     "next": "16.1.5",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      motion:
+        specifier: ^12.34.2
+        version: 12.34.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next:
         specifier: 16.1.5
         version: 16.1.5(@babel/core@7.28.6)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -3124,6 +3127,20 @@ packages:
       typescript: '>3.6.0'
       webpack: ^5.11.0
 
+  framer-motion@12.34.2:
+    resolution: {integrity: sha512-CcnYTzbRybm1/OE8QLXfXI8gR1cx5T4dF3D2kn5IyqsGNeLAKl2iFHb2BzFyXBGqESntDt6rPYl4Jhrb7tdB8g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
@@ -3806,6 +3823,26 @@ packages:
 
   module-alias@2.3.4:
     resolution: {integrity: sha512-bOclZt8hkpuGgSSoG07PKmvzTizROilUTvLNyrMqvlC9snhs7y7GzjNWAVbISIOlhCP1T14rH1PDAV9iNyBq/w==}
+
+  motion-dom@12.34.2:
+    resolution: {integrity: sha512-n7gknp7gHcW7DUcmet0JVPLVHmE3j9uWwDp5VbE3IkCNnW5qdu0mOhjNYzXMkrQjrgr+h6Db3EDM2QBhW2qNxQ==}
+
+  motion-utils@12.29.2:
+    resolution: {integrity: sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==}
+
+  motion@12.34.2:
+    resolution: {integrity: sha512-QAthwCtW6N0TpZ+bBmBMzdwuftoay2yFV2DT44jRcUQhPbFPdAX+pjzmIUNM3sMYDD5OAraJagRGAKE8q5OsmA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
@@ -8461,6 +8498,15 @@ snapshots:
       typescript: 5.9.3
       webpack: 5.105.0(esbuild@0.27.3)
 
+  framer-motion@12.34.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      motion-dom: 12.34.2
+      motion-utils: 12.29.2
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   fs-extra@10.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -9140,6 +9186,20 @@ snapshots:
   minipass@7.1.2: {}
 
   module-alias@2.3.4: {}
+
+  motion-dom@12.34.2:
+    dependencies:
+      motion-utils: 12.29.2
+
+  motion-utils@12.29.2: {}
+
+  motion@12.34.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      framer-motion: 12.34.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   mrmime@2.0.1: {}
 

--- a/styles/VisuallyHidden.tsx
+++ b/styles/VisuallyHidden.tsx
@@ -1,0 +1,12 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+const VisuallyHidden = (props: ComponentPropsWithoutRef<"button">) => {
+  return (
+    <button
+      {...props}
+      className="absolute w-px h-px overflow-hidden [clip:rect(0,0,0,0)] whitespace-nowrap focus:[clip:auto] focus:w-auto focus:h-auto focus:p-2 focus:border-2 focus:border-[blue]"
+    />
+  );
+};
+
+export { VisuallyHidden };


### PR DESCRIPTION
## 📌 요약

공용으로 사용할 스와이프 컴포넌트 제작

## ✨ 변경 사항

![햘](https://github.com/user-attachments/assets/3e5a9734-30ca-4315-b81c-3174d773bf21)

- useSwiperAction : swiper 연산 로직을 모아둔 훅 (가독성을 위해 컴포넌트에서 분리함)
- SwiperAction 컴포넌트 : 내부에 들어오는 Element를 감싸 Swiper 기능을 사용할 수 있도록 만드는 컴포넌트

### 사용 방법
- sidePeekRatio props를 조절하여 양옆에 보이는 이전/다음 요소의 크기를 정의할 수 있음
  - sidePeekRatio를 통해 요소의 width의 어느 정도가 보이도록 만들 것인지를 지정할 수 있음
  ex) 0.3 -> 내부 요소 너비의 30%가 보임

## 🔍 관련 이슈

- Closes #42 

## 🧪 테스트

- [x] 스토리북 정상 동작 확인

## 📝 기타 참고 사항

[구체적인_구현_로직](https://hanheel.tistory.com/entry/%EC%84%9C%EB%B9%84%EC%8A%A4%EC%97%90-%EB%A7%9E%EB%8A%94-%EC%BA%90%EB%9F%AC%EC%85%80%EC%9D%84-%EC%A7%81%EC%A0%91-%EC%84%A4%EA%B3%84%ED%95%98%EA%B8%B0-1-%ED%84%B0%EC%B9%98%EC%9D%B4%EB%B2%A4%ED%8A%B8%EB%A1%9C-%EA%B5%AC%ED%98%84%ED%95%98%EB%8A%94-%EC%BA%90%EB%9F%AC%EC%85%80)


