### PR TITLE
feature: image 그리드 컴포넌트 제작

### DIFF
--- a/components/ui/imageGrid/ImageGrid.stories.tsx
+++ b/components/ui/imageGrid/ImageGrid.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import ImageGrid from "./ImageGrid";
+
+const meta: Meta<typeof ImageGrid> = {
+  title: "UI/ImageGrid/ImageGrid",
+  component: ImageGrid,
+};
+
+export default meta;
+type Story = StoryObj<typeof ImageGrid>;
+
+const sampleImages = [
+  { src: "https://picsum.photos/seed/1/200/200", alt: "음식 이미지 1" },
+  { src: "https://picsum.photos/seed/2/200/200", alt: "음식 이미지 2" },
+  { src: "https://picsum.photos/seed/3/200/200", alt: "음식 이미지 3" },
+  { src: "https://picsum.photos/seed/4/200/200", alt: "음식 이미지 4" },
+  { src: "https://picsum.photos/seed/5/200/200", alt: "음식 이미지 5" },
+  { src: "https://picsum.photos/seed/6/200/200", alt: "음식 이미지 6" },
+  { src: "https://picsum.photos/seed/1/200/200", alt: "음식 이미지 1" },
+  { src: "https://picsum.photos/seed/2/200/200", alt: "음식 이미지 2" },
+  { src: "https://picsum.photos/seed/3/200/200", alt: "음식 이미지 3" },
+  { src: "https://picsum.photos/seed/4/200/200", alt: "음식 이미지 4" },
+  { src: "https://picsum.photos/seed/5/200/200", alt: "음식 이미지 5" },
+  { src: "https://picsum.photos/seed/6/200/200", alt: "음식 이미지 6" },
+  { src: "https://picsum.photos/seed/1/200/200", alt: "음식 이미지 1" },
+  { src: "https://picsum.photos/seed/2/200/200", alt: "음식 이미지 2" },
+  { src: "https://picsum.photos/seed/3/200/200", alt: "음식 이미지 3" },
+  { src: "https://picsum.photos/seed/4/200/200", alt: "음식 이미지 4" },
+  { src: "https://picsum.photos/seed/5/200/200", alt: "음식 이미지 5" },
+  { src: "https://picsum.photos/seed/6/200/200", alt: "음식 이미지 6" },
+];
+
+export const Default: Story = {
+  args: {
+    imageInfos: sampleImages,
+  },
+};
+
+export const ThreeImages: Story = {
+  args: {
+    imageInfos: sampleImages.slice(0, 3),
+  },
+};
+
+export const OneImage: Story = {
+  args: {
+    imageInfos: sampleImages.slice(0, 1),
+  },
+};

--- a/components/ui/imageGrid/ImageGrid.stories.tsx
+++ b/components/ui/imageGrid/ImageGrid.stories.tsx
@@ -16,18 +16,9 @@ const sampleImages = [
   { src: "https://picsum.photos/seed/4/200/200", alt: "음식 이미지 4" },
   { src: "https://picsum.photos/seed/5/200/200", alt: "음식 이미지 5" },
   { src: "https://picsum.photos/seed/6/200/200", alt: "음식 이미지 6" },
-  { src: "https://picsum.photos/seed/1/200/200", alt: "음식 이미지 1" },
-  { src: "https://picsum.photos/seed/2/200/200", alt: "음식 이미지 2" },
-  { src: "https://picsum.photos/seed/3/200/200", alt: "음식 이미지 3" },
-  { src: "https://picsum.photos/seed/4/200/200", alt: "음식 이미지 4" },
-  { src: "https://picsum.photos/seed/5/200/200", alt: "음식 이미지 5" },
-  { src: "https://picsum.photos/seed/6/200/200", alt: "음식 이미지 6" },
-  { src: "https://picsum.photos/seed/1/200/200", alt: "음식 이미지 1" },
-  { src: "https://picsum.photos/seed/2/200/200", alt: "음식 이미지 2" },
-  { src: "https://picsum.photos/seed/3/200/200", alt: "음식 이미지 3" },
-  { src: "https://picsum.photos/seed/4/200/200", alt: "음식 이미지 4" },
-  { src: "https://picsum.photos/seed/5/200/200", alt: "음식 이미지 5" },
-  { src: "https://picsum.photos/seed/6/200/200", alt: "음식 이미지 6" },
+  { src: "https://picsum.photos/seed/7/200/200", alt: "음식 이미지 1" },
+  { src: "https://picsum.photos/seed/8/200/200", alt: "음식 이미지 2" },
+  { src: "https://picsum.photos/seed/9/200/200", alt: "음식 이미지 3" },
 ];
 
 export const Default: Story = {

--- a/components/ui/imageGrid/ImageGrid.tsx
+++ b/components/ui/imageGrid/ImageGrid.tsx
@@ -1,0 +1,24 @@
+import Image from "next/image";
+
+interface ImageInfoType {
+  src: string;
+  alt: string;
+}
+
+interface ImageGridProps {
+  imageInfos: ImageInfoType[];
+}
+
+const ImageGrid = ({ imageInfos }: ImageGridProps) => {
+  return (
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(80px,1fr))] gap-2 px-4">
+      {imageInfos.map(({ src, alt }) => (
+        <div key={src} className="relative aspect-square overflow-hidden rounded-xl">
+          <Image fill sizes="110px" src={src} alt={alt} className="object-cover" />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ImageGrid;

--- a/components/ui/imageGrid/ImageGrid.tsx
+++ b/components/ui/imageGrid/ImageGrid.tsx
@@ -12,8 +12,9 @@ interface ImageGridProps {
 const ImageGrid = ({ imageInfos }: ImageGridProps) => {
   return (
     <div className="grid grid-cols-[repeat(auto-fill,minmax(80px,1fr))] gap-2 px-4">
-      {imageInfos.map(({ src, alt }) => (
-        <div key={src} className="relative aspect-square overflow-hidden rounded-xl">
+      {imageInfos.map(({ src, alt }, index) => (
+        //biome-ignore lint/suspicious/noArrayIndexKey: src와 index의 조합을 사용
+        <div key={`${src}-${index}`} className="relative aspect-square overflow-hidden rounded-xl">
           <Image fill sizes="110px" src={src} alt={alt} className="object-cover" />
         </div>
       ))}


### PR DESCRIPTION
## 📌 요약
이미지 그리드 컴포넌트 제작

## ✨ 변경 사항

<img width="378" height="460" alt="image" src="https://github.com/user-attachments/assets/6129f907-06d3-4410-b73b-a6479689a13d" />

- image의 src와 alt 정보를 넘겨줄 경우 렌더링 되도록 구현

## 🔍 관련 이슈

- Closes #44 

## 🧪 테스트

- [x] 스토리북 정상 동작 확인
