### PR TITLE
fix: 헤더 및 아이콘 에러 수정

### DIFF
--- a/components/layout/header/Header.tsx
+++ b/components/layout/header/Header.tsx
@@ -22,10 +22,10 @@ const Header = ({ title, fallbackRoute }: HeaderProps) => {
 
   return (
     <header className="relative flex py-4 w-full items-center bg-bg-oatmeal mb-1">
-      <button type="button" aria-label="뒤로 가기" className="absolute left-4 flex items-center justify-center p-1" onClick={handleBack}>
+      <button type="button" aria-label="뒤로 가기" className="absolute left-0 flex items-center justify-center" onClick={handleBack}>
         <ArrowLeft aria-hidden="true" className="h-4 w-4 text-gray-900" />
       </button>
-      <h1 className="typo-body1 mx-auto text-primary-text user-select">{title}</h1>
+      <h1 className="typo-body1 mx-auto text-primary-text user-select truncate w-[calc(100%-2rem)] text-center">{title}</h1>
     </header>
   );
 };

--- a/components/ui/searchBar/SearchBar.tsx
+++ b/components/ui/searchBar/SearchBar.tsx
@@ -11,8 +11,8 @@ interface SearchBarProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "on
 const SearchBar = ({ ...restProps }: SearchBarProps) => {
   return (
     <div className="inline-flex justify-center items-center gap-4 text-gray-400 bg-bg-white w-full py-3 px-7 rounded-full focus-within:ring-2 focus-within:ring-primary-base">
-      <div className="w-5 h-5 aspect-square flex justify-center items-center" aria-hidden="true">
-        <SearchIcon />
+      <div aria-hidden="true">
+        <SearchIcon className="w-5 h-5" />
       </div>
       <input type="search" aria-label="검색" className="flex-1 text-gray-900 focus-visible:outline-none text-body2" {...restProps} />
     </div>


### PR DESCRIPTION
## 📌 요약

모바일 UI 상 에러 수정

## ✨ 변경 사항
1. Header x방향 padding 없애기
2. 모바일에서 SearchIcon이 보이지 않는 문제 해결
3. 학교명이 길어질 경우 헤더 학교명 ... 처리

## 🔍 관련 이슈

- Closes #64 

## 🧪 테스트

- [x] 로컬에서 정상 동작 확인
