### PR TITLE
feature: Header 스크롤 방향에 따른 숨김/노출 구현

### DIFF
--- a/components/layout/header/Header.stories.tsx
+++ b/components/layout/header/Header.stories.tsx
@@ -30,3 +30,53 @@ export const Default: Story = {
     },
   },
 };
+
+export const WithFallbackRoute: Story = {
+  args: {
+    title: "식당 상세",
+    fallbackRoute: "/",
+  },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/restaurant/1",
+        query: {},
+      },
+    },
+  },
+};
+
+/**
+ * 스크롤 숨김/노출 동작을 확인하려면 스토리 내에서 스크롤을 시도하세요.
+ * - 아래로 스크롤: 헤더 숨김
+ * - 위로 스크롤: 헤더 노출
+ * - 최상단: 항상 노출
+ */
+export const ScrollBehavior: Story = {
+  args: {
+    title: "스크롤 테스트",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: "200vh", paddingTop: "0" }}>
+        <Story />
+        <div className="p-4 mt-4 space-y-4">
+          {Array.from({ length: 20 }, (_, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: 스토리용 더미 컨텐츠
+            <div key={i} className="h-12 bg-gray-100 rounded flex items-center justify-center">
+              스크롤 컨텐츠 {i + 1}
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+  ],
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/",
+        query: {},
+      },
+    },
+  },
+};

--- a/components/layout/header/Header.tsx
+++ b/components/layout/header/Header.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { motion } from "motion/react";
 import ArrowLeft from "@/assets/icons/arrow-left.svg";
+import useScrollDirection from "@/hooks/useScrollDirection";
 
 interface HeaderProps {
   /** 헤더 중앙에 표시될 페이지 제목 */
@@ -12,6 +14,8 @@ interface HeaderProps {
 
 const Header = ({ title, fallbackRoute }: HeaderProps) => {
   const router = useRouter();
+  const { isVisible } = useScrollDirection();
+
   const handleBack = () => {
     if (fallbackRoute) {
       router.replace(fallbackRoute);
@@ -21,12 +25,16 @@ const Header = ({ title, fallbackRoute }: HeaderProps) => {
   };
 
   return (
-    <header className="relative flex py-4 w-full items-center bg-bg-oatmeal mb-1">
+    <motion.header
+      className="sticky top-0 z-10 flex py-4 w-full items-center bg-bg-oatmeal mb-1"
+      animate={{ y: isVisible ? 0 : "-100%" }}
+      transition={{ duration: 0.3, ease: "easeInOut" }}
+    >
       <button type="button" aria-label="뒤로 가기" className="absolute left-0 flex items-center justify-center" onClick={handleBack}>
         <ArrowLeft aria-hidden="true" className="h-4 w-4 text-gray-900" />
       </button>
       <h1 className="typo-body1 mx-auto text-primary-text user-select truncate w-[calc(100%-2rem)] text-center">{title}</h1>
-    </header>
+    </motion.header>
   );
 };
 

--- a/hooks/useScrollDirection.ts
+++ b/hooks/useScrollDirection.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface UseScrollDirectionOptions {
   /** 스크롤 방향 감지를 위한 최소 이동 거리 (px). 미세한 스크롤을 무시한다. @default 5 */
@@ -19,15 +19,18 @@ interface UseScrollDirectionResult {
  * - 최상단(scrollY === 0)일 경우 항상 isVisible: true
  * @param options - threshold: 스크롤 방향 감지 최소 이동 거리 (기본값: 5px)
  */
-const useScrollDirection = ({ threshold = 5 }: UseScrollDirectionOptions = {}): UseScrollDirectionResult => {
+const useScrollDirection = ({
+  threshold = 5,
+}: UseScrollDirectionOptions = {}): UseScrollDirectionResult => {
   const [isVisible, setIsVisible] = useState(true);
+  const lastScrollY = useRef(0);
 
   useEffect(() => {
-    let lastScrollY = window.scrollY;
+    lastScrollY.current = window.scrollY;
 
     const handleScroll = () => {
       const currentScrollY = window.scrollY;
-      const diff = currentScrollY - lastScrollY;
+      const diff = currentScrollY - lastScrollY.current;
 
       if (currentScrollY <= 0) {
         setIsVisible(true);
@@ -35,7 +38,7 @@ const useScrollDirection = ({ threshold = 5 }: UseScrollDirectionOptions = {}): 
         setIsVisible(diff < 0);
       }
 
-      lastScrollY = currentScrollY;
+      lastScrollY.current = currentScrollY;
     };
 
     window.addEventListener("scroll", handleScroll, { passive: true });

--- a/hooks/useScrollDirection.ts
+++ b/hooks/useScrollDirection.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface UseScrollDirectionOptions {
+  /** 스크롤 방향 감지를 위한 최소 이동 거리 (px). 미세한 스크롤을 무시한다. @default 5 */
+  threshold?: number;
+}
+
+interface UseScrollDirectionResult {
+  /** 헤더가 표시되어야 하는 상태. 최상단이거나 위로 스크롤 시 true, 아래로 스크롤 시 false */
+  isVisible: boolean;
+}
+
+/**
+ * 스크롤 방향에 따라 요소의 표시 여부를 관리하는 훅
+ * - 아래로 스크롤 시 isVisible: false
+ * - 위로 스크롤 시 isVisible: true
+ * - 최상단(scrollY === 0)일 경우 항상 isVisible: true
+ * @param options - threshold: 스크롤 방향 감지 최소 이동 거리 (기본값: 5px)
+ */
+const useScrollDirection = ({ threshold = 5 }: UseScrollDirectionOptions = {}): UseScrollDirectionResult => {
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    let lastScrollY = window.scrollY;
+
+    const handleScroll = () => {
+      const currentScrollY = window.scrollY;
+      const diff = currentScrollY - lastScrollY;
+
+      if (currentScrollY <= 0) {
+        setIsVisible(true);
+      } else if (Math.abs(diff) >= threshold) {
+        setIsVisible(diff < 0);
+      }
+
+      lastScrollY = currentScrollY;
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [threshold]);
+
+  return { isVisible };
+};
+
+export default useScrollDirection;


### PR DESCRIPTION
## 작업 내용

스크롤 방향을 감지하여 헤더를 동적으로 숨기거나 노출하는 기능을 구현했습니다.
아래로 스크롤 시 헤더가 사라지고, 위로 스크롤하거나 최상단일 때 다시 나타납니다.

## 변경 사항

- `hooks/useScrollDirection.ts` 신규 추가
  - 스크롤 방향 감지 커스텀 훅 구현
  - `threshold` 옵션으로 미세한 스크롤 무시 (기본값 5px)
  - 최상단(`scrollY === 0`)일 경우 항상 `isVisible: true`
  - 초기 스크롤 위치를 `useRef`로 관리 (의도 명시)
- `components/layout/header/Header.tsx` 수정
  - `<header>` → `<motion.header>`로 교체하여 슬라이드 애니메이션 적용
  - `useScrollDirection` 훅 연동, `isVisible` 상태에 따라 translateY 제어
  - `sticky top-0 z-10` 적용으로 스크롤 시 고정 위치 유지
- `components/layout/header/Header.stories.tsx` 수정
  - `ScrollBehavior` 스토리 추가 (200vh 높이 환경에서 스크롤 동작 확인 가능)

## 설계 결정

- `let` 대신 `useRef`를 사용하여 이전 스크롤 위치를 기록: 렌더링과 무관한 참조값임을 명시적으로 표현
- `threshold` 옵션으로 미세한 스크롤에 의한 불필요한 토글 방지
- `motion/react`의 `animate`를 사용하여 `translateY` 기반 슬라이드 인/아웃 (duration 0.3s, easeInOut)

## 스크린샷

<!-- Storybook의 ScrollBehavior 스토리에서 동작 확인 가능 -->

## 체크리스트

- [ ] 빌드 통과
- [ ] 타입 에러 없음
- [ ] 테스트 작성 (도메인 로직)
- [x] Storybook 작성 (컴포넌트)
- [ ] 접근성 처리

Closes #58