### PR TITLE
[feat] #72 바텀시트 컴포넌트 구현

### DIFF
--- a/components/ui/bottomSheet/BottomSheet.stories.tsx
+++ b/components/ui/bottomSheet/BottomSheet.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { useState } from "react";
+import BottomSheet from "./BottomSheet";
+
+const meta: Meta<typeof BottomSheet> = {
+  title: "UI/BottomSheet/BottomSheet",
+  component: BottomSheet,
+};
+
+export default meta;
+type Story = StoryObj<typeof BottomSheet>;
+
+export const Default: Story = {
+  render: () => {
+    // biome-ignore lint/correctness/useHookAtTopLevel: 스토리 render 함수에서 훅 사용
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <div className="relative h-[600px] bg-bg-oatmeal">
+        <button
+          type="button"
+          className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-point px-6 py-3 typo-button text-white"
+          onClick={() => setIsOpen(true)}
+        >
+          바텀시트 열기
+        </button>
+        <BottomSheet isOpen={isOpen} toggleOpen={() => setIsOpen((prev) => !prev)}>
+          <div className="px-5 pb-8 pt-2">
+            <h2 className="typo-h2-sub mb-4 text-center text-primary-text">바텀시트 제목</h2>
+            <p className="typo-body2 text-secondary-subtext">바텀시트 내용이 여기에 들어갑니다. children으로 원하는 컨텐츠를 넣을 수 있습니다.</p>
+          </div>
+        </BottomSheet>
+      </div>
+    );
+  },
+};
+
+export const WithLongContent: Story = {
+  render: () => {
+    // biome-ignore lint/correctness/useHookAtTopLevel: 스토리 render 함수에서 훅 사용
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <div className="relative h-[600px] bg-bg-oatmeal">
+        <button
+          type="button"
+          className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-point px-6 py-3 typo-button text-white"
+          onClick={() => setIsOpen(true)}
+        >
+          긴 컨텐츠 바텀시트 열기
+        </button>
+        <BottomSheet isOpen={isOpen} toggleOpen={() => setIsOpen((prev) => !prev)}>
+          <div className="px-5 pb-8 pt-2">
+            <h2 className="typo-h2-sub mb-6 text-center text-primary-text">새 폴더 만들기</h2>
+            <div className="flex flex-col gap-6">
+              <div className="flex flex-col gap-2">
+                <label className="typo-body1 text-primary-text">폴더 이름</label>
+                <div className="flex h-[52px] items-center rounded-xl border border-gray-200 px-4">
+                  <span className="typo-body2 text-secondary-subtext">예: 비 오는 날 파전 맛집</span>
+                </div>
+              </div>
+              <div className="flex flex-col gap-2">
+                <label className="typo-body1 text-primary-text">짧은 설명</label>
+                <div className="flex h-[52px] items-center rounded-xl border border-gray-200 px-4">
+                  <span className="typo-body2 text-secondary-subtext">예: 막걸리 필수, 웨이팅 감수!</span>
+                </div>
+              </div>
+            </div>
+            <div className="mt-6">
+              <button
+                type="button"
+                className="w-full rounded-full bg-primary-point py-[14px] typo-button text-white shadow-[0px_4px_12px_0px_var(--color-shadow)]"
+              >
+                폴더 생성하기
+              </button>
+            </div>
+          </div>
+        </BottomSheet>
+      </div>
+    );
+  },
+};

--- a/components/ui/bottomSheet/BottomSheet.tsx
+++ b/components/ui/bottomSheet/BottomSheet.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import clsx from "clsx";
+import { useEffect } from "react";
+
+interface BottomSheetProps {
+  /** 바텀시트 열림 여부 */
+  isOpen: boolean;
+  /** 바텀시트 열림/닫힘 토글 함수 */
+  toggleOpen: () => void;
+  /** 바텀시트 내부 컨텐츠 */
+  children: React.ReactNode;
+}
+
+const BottomSheet = ({ isOpen, toggleOpen, children }: BottomSheetProps) => {
+  // ESC 키로 닫기
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") toggleOpen();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, toggleOpen]);
+
+  // 바텀시트 열릴 때 body 스크롤 잠금
+  useEffect(() => {
+    document.body.style.overflow = isOpen ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  return (
+    <>
+      {/* Overlay */}
+      <div
+        className={clsx(
+          "fixed inset-0 z-[60] bg-black/40 transition-opacity duration-300",
+          isOpen ? "opacity-100" : "pointer-events-none opacity-0",
+        )}
+        onClick={toggleOpen}
+        aria-hidden="true"
+      />
+
+      {/* Bottom Sheet */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="바텀시트"
+        className={clsx(
+          "fixed bottom-0 left-0 right-0 z-[70] mx-auto max-w-layout",
+          "rounded-t-[24px] bg-white",
+          "transition-transform duration-300 ease-out",
+          isOpen ? "translate-y-0" : "translate-y-full",
+        )}
+      >
+        {/* Handle Bar */}
+        <div className="flex justify-center pb-2 pt-3" aria-hidden="true">
+          <div className="h-1 w-10 rounded-full bg-gray-100" />
+        </div>
+
+        {/* Content */}
+        {children}
+      </div>
+    </>
+  );
+};
+
+export default BottomSheet;


### PR DESCRIPTION
## 작업 내용

바텀시트 컴포넌트를 구현했습니다. 하단에서 위로 부드럽게 올라오는 애니메이션과 외부 영역 클릭 시 닫힘 동작을 포함합니다.

## 변경 사항

- `components/ui/bottomSheet/BottomSheet.tsx` — 바텀시트 컴포넌트 구현
- `components/ui/bottomSheet/BottomSheet.stories.tsx` — Storybook 스토리 작성

## 구현한 컴포넌트

- `BottomSheet` — `isOpen`, `toggleOpen`, `children` props 기반의 바텀시트

## 설계 결정

- **오버레이 z-index**: `z-[60]`, 바텀시트 `z-[70]` — 기존 `--z-floating: 50` 위에 레이어링
- **max-w-layout**: `fixed` 포지셔닝에서도 레이아웃 너비(375px)에 맞게 `mx-auto max-w-layout` 적용
- **body scroll lock**: 바텀시트 열림 시 `document.body.style.overflow = "hidden"` 처리
- **Figma 대비 의도적 차이**: 내부 컨텐츠(폼 필드, 버튼)는 이슈 스펙에 따라 `children`으로 위임. 핸들 바만 컴포넌트에 포함

## 접근성 처리

- `role="dialog"`, `aria-modal="true"` 로 다이얼로그 역할 명시
- 오버레이에 `aria-hidden="true"` 처리
- ESC 키로 닫기 지원

## Tailwind v4 문법 활용

- `bg-black/40` — v4 투명도 modifier 활용
- `translate-y-full` / `translate-y-0` 전환으로 슬라이드 애니메이션 구현
- `max-w-layout` — `@theme inline`의 `--container-layout` 토큰 활용

## 스크린샷

> Storybook에서 확인 (`UI/BottomSheet/BottomSheet`)

## 체크리스트

- [ ] 빌드 통과
- [x] 타입 에러 없음
- [x] Storybook 작성
- [x] 접근성 처리

Closes #72