### PR TITLE
[feat] #76 메뉴판 컴포넌트 구현

### DIFF
--- a/components/ui/menuBoard/MenuBoard.stories.tsx
+++ b/components/ui/menuBoard/MenuBoard.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import MenuBoard from "./MenuBoard";
+
+const meta: Meta<typeof MenuBoard> = {
+  title: "components/ui/menuBoard/MenuBoard",
+  component: MenuBoard,
+};
+
+export default meta;
+type Story = StoryObj<typeof MenuBoard>;
+
+export const Default: Story = {
+  args: {
+    menus: [
+      { name: "직화 제육볶음", price: 9000 },
+      { name: "치즈 김치찜", price: 9500 },
+      { name: "수제 떡갈비 정식", price: 11000 },
+      { name: "계란찜 추가", price: 3000 },
+    ],
+  },
+};
+
+export const SingleItem: Story = {
+  args: {
+    menus: [{ name: "오늘의 정식", price: 8500 }],
+  },
+};

--- a/components/ui/menuBoard/MenuBoard.tsx
+++ b/components/ui/menuBoard/MenuBoard.tsx
@@ -1,0 +1,30 @@
+interface MenuInfo {
+  /** 메뉴 이름 */
+  name: string;
+  /** 메뉴 가격 (원 단위) */
+  price: number;
+}
+
+interface MenuBoardProps {
+  /** 표시할 메뉴 목록 */
+  menus: MenuInfo[];
+}
+
+/**
+ * 메뉴판 컴포넌트
+ * @param menus - 메뉴 이름과 가격 배열
+ */
+const MenuBoard = ({ menus }: MenuBoardProps) => {
+  return (
+    <ul className="flex w-full flex-col text-primary-text" role="list" aria-label="메뉴판">
+      {menus.map((menu) => (
+        <li key={menu.name} className="flex items-center justify-between px-5 py-1">
+          <span className="typo-body2">{menu.name}</span>
+          <span className="typo-body1 text-right">{menu.price.toLocaleString("ko-KR")}원</span>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default MenuBoard;


### PR DESCRIPTION
## 작업 내용

메뉴 이름과 가격 배열을 받아 메뉴판 UI를 렌더링하는 `MenuBoard` 컴포넌트를 구현했습니다.

## 변경 사항

- `components/ui/menuBoard/MenuBoard.tsx` 추가
- `components/ui/menuBoard/MenuBoard.stories.tsx` 추가

## 구현한 컴포넌트

- `MenuBoard`: `menus: MenuInfo[]` props를 받아 메뉴명(좌)/가격(우) 레이아웃으로 렌더링

## 설계 결정

**Props 인터페이스 이름 변경**

이슈에 명시된 `MenuInfos` → `MenuInfo`로 변경했습니다. 단수형이 단일 항목을 나타내는 의미에 더 적합하다고 판단했습니다.

**가격 포맷팅**

`price.toLocaleString("ko-KR")`으로 천 단위 구분자를 적용했습니다. 예: `11000` → `11,000원`

**Tailwind v4 문법 활용**

`typo-body1`, `typo-body2` `@utility` 클래스를 직접 사용하여 Figma 디자인 토큰과 매핑했습니다.

## 접근성 처리 방식

- `<ul role="list" aria-label="메뉴판">` 으로 목록 의미론 명시
- `<li>` 태그로 각 메뉴 항목 마크업

## 스크린샷

> Chromatic 미배포 (토큰 없음)

## 체크리스트

- [x] 빌드 통과
- [x] 타입 에러 없음
- [ ] 테스트 작성 (도메인 로직) — 순수 렌더링 컴포넌트로 도메인 로직 없음
- [x] Storybook 작성
- [x] 접근성 처리

Closes #76