### PR TITLE
[feat] #77 위키 뷰어 컴포넌트 구현

### DIFF
--- a/app/(tabs)/restaurants/[id]/wiki/page.tsx
+++ b/app/(tabs)/restaurants/[id]/wiki/page.tsx
@@ -1,6 +1,25 @@
-// TODO: 식당 위키 탭 구현
+import WikiViewer from "@/components/specific/wiki/WikiViewer";
+
+const MOCK_SECTIONS = [
+  {
+    title: "1. 영업 시간 및 휴무",
+    content: "평일 11:00~20:00 (브레이크 타임 15:00~17:00)",
+  },
+  {
+    title: "2. 꿀팁 및 TMI",
+    content: `- 밥 무한리필 가능. 제육 소스 조금 더 달라고 해서 비벼먹으면 극락임.
+- 혼밥석은 창가 쪽에 4자리 있음. **혼밥 난이도 최하.**
+- 결제 시 계좌이체 하면 계란 후라이를 서비스로 주신다.
+- 사장님 피셜: 재료 소진 시 조기 마감될 수 있으니 저녁엔 일찍 가는 것을 추천함.`,
+  },
+];
+
 const WikiPage = () => {
-  return <div className="py-6" />;
+  return (
+    <div className="py-6">
+      <WikiViewer sections={MOCK_SECTIONS} />
+    </div>
+  );
 };
 
 export default WikiPage;

--- a/components/specific/wiki/WikiViewer.tsx
+++ b/components/specific/wiki/WikiViewer.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import clsx from "clsx";
+import { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import ChevronRightIcon from "@/assets/icons/chevron-right.svg";
+import EditIcon from "@/assets/icons/edit.svg";
+
+interface WikiSection {
+  /** 섹션 제목 */
+  title: string;
+  /** 마크다운 형식의 섹션 내용 */
+  content: string;
+}
+
+interface WikiViewerProps {
+  /** 위키 섹션 목록 */
+  sections: WikiSection[];
+}
+
+/**
+ * 마크다운 기반 위키 뷰어 컴포넌트
+ * @param sections - 제목과 마크다운 내용으로 구성된 섹션 배열
+ */
+const WikiViewer = ({ sections }: WikiViewerProps) => {
+  const [openIndexes, setOpenIndexes] = useState<Set<number>>(
+    () => new Set(sections.map((_, i) => i)),
+  );
+
+  const toggle = (index: number) => {
+    setOpenIndexes((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="flex flex-col">
+      {sections.map((section, index) => {
+        const isOpen = openIndexes.has(index);
+        return (
+          <div key={section.title}>
+            <div className="flex items-center justify-between px-5 py-4">
+              <button
+                type="button"
+                className="flex flex-1 items-center gap-2"
+                onClick={() => toggle(index)}
+                aria-expanded={isOpen}
+                aria-controls={`wiki-section-${index}`}
+              >
+                <ChevronRightIcon
+                  className={clsx(
+                    "h-5 w-5 text-primary-point transition-transform duration-200",
+                    isOpen ? "rotate-90" : "rotate-0",
+                  )}
+                  aria-hidden="true"
+                />
+                <span className="typo-h2-sub text-primary-text">{section.title}</span>
+              </button>
+              {/* 편집 아이콘 영역 - 추후 편집 기능 구현 시 활성화 */}
+              <div aria-hidden="true">
+                <EditIcon className="h-5 w-5 text-gray-400" />
+              </div>
+            </div>
+
+            <div className="mx-5 h-px bg-gray-200" />
+
+            {isOpen && (
+              <div
+                id={`wiki-section-${index}`}
+                className="typo-body2 px-5 py-4 text-primary-text"
+              >
+                <ReactMarkdown
+                  components={{
+                    p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+                    ul: ({ children }) => <ul className="list-disc space-y-1 pl-5">{children}</ul>,
+                    strong: ({ children }) => <strong className="font-bold">{children}</strong>,
+                  }}
+                >
+                  {section.content}
+                </ReactMarkdown>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default WikiViewer;

--- a/components/specific/wiki/WikiViewer.tsx
+++ b/components/specific/wiki/WikiViewer.tsx
@@ -3,6 +3,7 @@
 import clsx from "clsx";
 import { useState } from "react";
 import ReactMarkdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
 import ChevronRightIcon from "@/assets/icons/chevron-right.svg";
 import EditIcon from "@/assets/icons/edit.svg";
 
@@ -76,6 +77,7 @@ const WikiViewer = ({ sections }: WikiViewerProps) => {
                 className="typo-body2 px-5 py-4 text-primary-text"
               >
                 <ReactMarkdown
+                  remarkPlugins={[remarkBreaks]}
                   components={{
                     p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
                     ul: ({ children }) => <ul className="list-disc space-y-1 pl-5">{children}</ul>,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "next": "16.1.5",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "remark-breaks": "^4.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.10)(react@19.2.3)
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.13
@@ -2936,6 +2939,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   eslint-config-next@16.1.5:
     resolution: {integrity: sha512-XwXyv65DC1HXI3gMxm13jvgx0IxKu6XhZhIWTfCDt4c45njHYUM2pk1Y8QXMAWMMnqPy94I2OLMmvIrNGcwLwQ==}
     peerDependencies:
@@ -3851,6 +3858,9 @@ packages:
   md5.js@1.3.5:
     resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
@@ -3862,6 +3872,9 @@ packages:
 
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
 
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
@@ -4484,6 +4497,9 @@ packages:
   relateurl@0.2.7:
     resolution: {integrity: sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==}
     engines: {node: '>= 0.10'}
+
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -8449,6 +8465,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   eslint-config-next@16.1.5(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.1.5
@@ -9469,6 +9487,13 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
 
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
@@ -9524,6 +9549,11 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
+
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
 
   mdast-util-phrasing@4.1.0:
     dependencies:
@@ -10307,6 +10337,12 @@ snapshots:
       jsesc: 3.1.0
 
   relateurl@0.2.7: {}
+
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
+      unified: 11.0.5
 
   remark-parse@11.0.0:
     dependencies:


### PR DESCRIPTION
## 작업 내용

`react-markdown`을 활용한 위키 조회용(Viewer) UI를 구현했습니다.

## 변경 사항

- `components/specific/wiki/WikiViewer.tsx` 추가
- `app/(tabs)/restaurants/[id]/wiki/page.tsx` mock 데이터로 업데이트

## 구현한 컴포넌트

**WikiViewer**
- `sections: WikiSection[]` props를 받아 섹션별 마크다운 렌더링
- 섹션 헤더 클릭으로 접힘/펼침 토글 (`chevron-right.svg` 90도 회전)
- 편집 아이콘 영역 예약 (`edit.svg`), 기능 미구현
- 모든 섹션은 초기 상태에서 펼쳐진 채로 표시

## Figma 대비 차이점

- Figma URL이 이슈에 잘못 연결되어 있어(이전 이슈의 MenuBoard 노드), 이슈에 첨부된 스크린샷을 기준으로 구현했습니다.

## 접근성 처리 방식

- 섹션 토글 버튼에 `aria-expanded` 상태 반영
- `aria-controls`로 콘텐츠 영역 연결
- 편집 아이콘에 `aria-hidden="true"` 처리

## Tailwind v4 문법 활용

- `typo-h2-sub`, `typo-body2` `@utility` 클래스로 Figma 디자인 토큰 매핑

## 체크리스트

- [x] 빌드 통과
- [x] 타입 에러 없음
- [ ] 테스트 작성 (도메인 로직) — 순수 UI 컴포넌트로 도메인 로직 없음
- [ ] Storybook 작성 — 이슈 AI 작업 범위: 코드 생성만
- [x] 접근성 처리

Closes #77