### PR TITLE
feature: 정렬 드롭다운 칩 컴포넌트 및 바텀시트 구현

### DIFF
--- a/app/(tabs)/folders/[id]/_components/SortDropdown.tsx
+++ b/app/(tabs)/folders/[id]/_components/SortDropdown.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import BottomSheet from "@/components/ui/bottomSheet/BottomSheet";
+import Dropdown from "@/components/ui/dropdown/Dropdown";
+import SortOptionList from "./SortOptionList";
+
+export type SortOption = "개수순" | "리뷰 개수순" | "거리순";
+
+const SORT_OPTIONS: SortOption[] = ["개수순", "리뷰 개수순", "거리순"];
+
+/**
+ * 식당 목록 정렬 옵션을 선택하는 드롭다운 + 바텀시트 컴포넌트.
+ * 실제 정렬 기능은 미구현 상태이며, UI 상태만 관리한다.
+ */
+const SortDropdown = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState<SortOption>("거리순");
+  const [pending, setPending] = useState<SortOption>("거리순");
+
+  const handleOpen = () => {
+    setPending(selected);
+    setIsOpen(true);
+  };
+
+  const handleToggle = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const handleConfirm = () => {
+    setSelected(pending);
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <Dropdown label={selected} onClick={handleOpen} aria-haspopup="dialog" />
+
+      <BottomSheet isOpen={isOpen} toggleOpen={handleToggle}>
+        <div className="px-5 pb-8">
+          {/* 제목 */}
+          <h2 className="typo-h2-sub pb-4 pt-6 text-center text-primary-text">
+            정렬 기준
+          </h2>
+
+          {/* 옵션 목록 */}
+          <SortOptionList options={SORT_OPTIONS} selected={pending} onSelect={setPending} />
+
+          {/* 완료 버튼 */}
+          <div className="pt-6">
+            <button
+              type="button"
+              className="h-14 w-full rounded-full bg-primary-point typo-button text-white shadow-[0px_4px_12px_0px_rgba(255,126,54,0.2)]"
+              onClick={handleConfirm}
+            >
+              완료
+            </button>
+          </div>
+        </div>
+      </BottomSheet>
+    </>
+  );
+};
+
+export default SortDropdown;

--- a/app/(tabs)/folders/[id]/_components/SortOptionList.tsx
+++ b/app/(tabs)/folders/[id]/_components/SortOptionList.tsx
@@ -1,0 +1,42 @@
+import type { SortOption } from "./SortDropdown";
+
+const CheckIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="M5 12L10 17L19 8" stroke="#FF7E36" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+interface SortOptionListProps {
+  /** 정렬 옵션 목록 */
+  options: SortOption[];
+  /** 현재 선택(pending) 상태의 옵션 */
+  selected: SortOption;
+  /** 옵션 선택 핸들러 */
+  onSelect: (option: SortOption) => void;
+}
+
+/**
+ * 정렬 바텀시트 내부의 옵션 리스트 컴포넌트.
+ * @param options - 표시할 정렬 옵션 목록
+ * @param selected - 현재 선택된 옵션
+ * @param onSelect - 옵션 선택 시 호출되는 콜백
+ */
+const SortOptionList = ({ options, selected, onSelect }: SortOptionListProps) => {
+  return (
+    <ul aria-label="정렬 기준 선택">
+      {options.map((option) => {
+        const isSelected = selected === option;
+        return (
+          <li key={option}>
+            <button type="button" className="flex w-full items-center justify-between py-2" onClick={() => onSelect(option)}>
+              <span className={`typo-body1 ${isSelected ? "text-primary-point" : "text-gray-500"}`}>{option}</span>
+              {isSelected && <CheckIcon />}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default SortOptionList;

--- a/app/(tabs)/folders/[id]/page.tsx
+++ b/app/(tabs)/folders/[id]/page.tsx
@@ -2,6 +2,7 @@ import Header from "@/components/layout/header/Header";
 import HashtagButton from "@/components/specific/hashtag/hashtagButton/HashtagButton";
 import { ROUTE } from "@/constants/routes";
 import RestaurantCard from "../_components/restaurantCard/RestaurantCard";
+import SortDropdown from "./_components/SortDropdown";
 
 interface RestaurantData {
   id: string;
@@ -65,19 +66,21 @@ interface FolderRestaurantListPageProps {
   params: Promise<{ id: string }>;
 }
 
-const FolderRestaurantListPage = async ({ params }: FolderRestaurantListPageProps) => {
+const FolderRestaurantListPage = async ({
+  params,
+}: FolderRestaurantListPageProps) => {
   const { id } = await params;
   const folder = MOCK_FOLDERS[id] ?? { emoji: "📁", title: "폴더" };
 
   return (
     <>
-      <Header title={`${folder.emoji} ${folder.title}`} fallbackRoute={ROUTE.FOLDER.INDEX} />
+      <Header
+        title={`${folder.emoji} ${folder.title}`}
+        fallbackRoute={ROUTE.FOLDER.INDEX}
+      />
       <div className="flex flex-col gap-6 pb-40">
         <div className="flex items-center gap-2">
-          {/* TODO: [SortDropdown] - 거리순 정렬 드롭다운 구현 필요 */}
-          <div className="h-8 w-24 border border-dashed border-gray-200 rounded-full flex items-center justify-center typo-caption text-gray-400" aria-hidden="true">
-            거리순
-          </div>
+          <SortDropdown />
           <HashtagButton text="영업중" isSelected={false} />
         </div>
 

--- a/components/ui/dropdown/Dropdown.stories.tsx
+++ b/components/ui/dropdown/Dropdown.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { useState } from "react";
+import BottomSheet from "@/components/ui/bottomSheet/BottomSheet";
+import Dropdown from "./Dropdown";
+
+const meta: Meta<typeof Dropdown> = {
+  title: "UI/Dropdown/Dropdown",
+  component: Dropdown,
+};
+
+export default meta;
+type Story = StoryObj<typeof Dropdown>;
+
+export const Sort: Story = {
+  args: {
+    label: "거리순",
+    variant: "sort",
+  },
+};
+
+export const WithBottomSheet: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <div className="relative h-[400px] bg-bg-oatmeal p-4">
+        <Dropdown label="거리순" onClick={() => setIsOpen(true)} />
+        <BottomSheet isOpen={isOpen} toggleOpen={() => setIsOpen((prev) => !prev)}>
+          <div className="px-5 pb-8 pt-2">
+            <h2 className="typo-h2-sub mb-4 text-center text-primary-text">정렬 기준</h2>
+            <ul className="flex flex-col gap-3">
+              {["거리순", "평점순", "최신순"].map((option) => (
+                <li key={option}>
+                  <button type="button" className="w-full rounded-xl py-3 text-left typo-body1 text-primary-text" onClick={() => setIsOpen(false)}>
+                    {option}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </BottomSheet>
+      </div>
+    );
+  },
+};

--- a/components/ui/dropdown/Dropdown.tsx
+++ b/components/ui/dropdown/Dropdown.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { cva } from "class-variance-authority";
+import type { ButtonHTMLAttributes } from "react";
+
+type DropdownVariant = "sort";
+
+interface DropdownProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** 칩에 표시할 텍스트 */
+  label: string;
+  /** 칩의 시각적 변형. sort: 화살표 포함 + 그림자 */
+  variant?: DropdownVariant;
+}
+
+const dropdownVariants = cva(["flex items-center justify-center rounded-full bg-bg-white text-gray-600 whitespace-nowrap cursor-pointer"], {
+  variants: {
+    variant: {
+      sort: ["gap-1 px-4 py-1.5 shadow-[0px_0px_5px_0px_rgba(32,32,32,0.05)] typo-button-sm"],
+    },
+  },
+  defaultVariants: {
+    variant: "sort",
+  },
+});
+
+const ChevronDown = () => (
+  <svg width="12" height="6" viewBox="0 0 12 6" fill="none" aria-hidden="true">
+    <path d="M1 1L6 5L11 1" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+/**
+ * 필터 조건을 선택하는 드롭다운 칩 버튼 컴포넌트.
+ * 클릭 동작은 외부에서 `onClick`으로 제어한다.
+ * @param label - 칩에 표시할 텍스트
+ * @param variant - 시각적 변형 (sort: 화살표 + 그림자)
+ */
+const Dropdown = ({ label, variant = "sort", ...rest }: DropdownProps) => {
+  return (
+    <button type="button" className={dropdownVariants({ variant })} {...rest}>
+      {label}
+      <ChevronDown />
+    </button>
+  );
+};
+
+export default Dropdown;


### PR DESCRIPTION
## 변경사항 요약

- `Dropdown` 칩 버튼 공통 컴포넌트 추가 (cva 기반 variant 관리, Storybook 포함)
- `SortDropdown` 컴포넌트 추가 — 선택 상태 관리 및 바텀시트 연동
- `SortOptionList` 컴포넌트 분리 — 정렬 옵션 리스트 렌더링 담당
- 폴더 식당 목록 페이지(`folder/[id]`)에 정렬 드롭다운 UI 적용

## 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

---

Closes #87